### PR TITLE
docs(readme): Remove links to Heroku deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,16 @@ Client for Hospital Patients.
 
 [![Build Status](https://travis-ci.org/halp-project/halp-patients-app.svg?branch=dev)](https://travis-ci.org/halp-project/halp-patients-app)
 
-## Environments
-- [Halp Patients App on Heroku - Master](https://halp-patients-app.herokuapp.com/) (stable, only for customer-oriented releases)
-- [Halp Patients App on Heroku - Development](https://halp-patients-app-staging.herokuapp.com/)
-
 ## Local development
 
-Run it on [Node 7.x](https://nodejs.org/es/) (Install it via [nvm](https://github.com/creationix/nvm)) after starting the [server](https://github.com/halp-project/halp-server).
+Run it on [Node.js 7.x](https://nodejs.org/es/) (install it via [nvm](https://github.com/creationix/nvm)) after starting the [server](https://github.com/halp-project/halp-server).
 ```bash
-npm install // Install dependencies 
-ng serve // Serve app in local http://localhost:4200/ 
+npm install # Install dependencies 
+ng serve # Serve app in local http://localhost:4200/ 
 ```
 
 More commands: [package.json](https://github.com/halp-project/halp-patients-app/blob/dev/package.json) & [Angular CLI](https://cli.angular.io/).
 
 ## Contribution Guides
 ### Commits
-Follow [Commitizen guidelines](https://github.com/commitizen/cz-cli) for commit messages by using `git cz` command instead of `git commit`.
+We follow [Commitizen convention](https://github.com/commitizen/cz-cli) for commit messages by using `git cz` command instead of `git commit`.


### PR DESCRIPTION
- Remove links to Heroku deployments (currently off)